### PR TITLE
Feature/cookie lang

### DIFF
--- a/app/client/package.json
+++ b/app/client/package.json
@@ -10,6 +10,7 @@
     "react": "^15.4.2",
     "react-axios": "^1.0.3",
     "react-bootstrap": "^0.30.8",
+    "react-cookie": "^2.0.8",
     "react-dom": "^15.4.2",
     "react-fontawesome": "^1.6.1",
     "react-router-bootstrap": "^0.24.2",

--- a/app/client/src/App.js
+++ b/app/client/src/App.js
@@ -1,5 +1,7 @@
 import React, { Component } from 'react';
 import { BrowserRouter, Switch, Route } from 'react-router-dom'
+import Cookies from 'universal-cookie';
+
 import CardinalNav from './components/CardinalNav';
 import CardinalFooter from './components/CardinalFooter';
 
@@ -25,10 +27,22 @@ class App extends Component {
     }
 
     componentDidMount() {
+
+        const cookies = new Cookies();
+
         const search = this.props.location.search; // could be '?foo=bar'
         const params = new URLSearchParams(search);
         const lang = params.get('lang'); // bar
-        var query = lang != null ? "?lang=" + lang : "";
+
+        if (lang != null){
+            cookies.set('lang', lang, { path: '/' });
+        }else{
+            if(cookies.get('lang') == null){
+                cookies.set('lang', 'en', { path: '/' });
+            }
+        }
+
+        var query = "?lang=" + cookies.get('lang');
         fetch(SERVER_URL + 'home/common' + query)
           .then(r => r.json())
           .then(json => this.setState({serverInfo: json}))

--- a/app/client/src/config.js
+++ b/app/client/src/config.js
@@ -1,5 +1,5 @@
 import pjson from './../package.json';
 
-export const SERVER_URL = 'http://localhost:8080/';
+export const SERVER_URL = 'http://52.15.192.135:8080/';
 export const CLIENT_VERSION = pjson.version;
 export const REACT_VERSION = pjson.dependencies.react;

--- a/app/client/src/config.js
+++ b/app/client/src/config.js
@@ -1,5 +1,5 @@
 import pjson from './../package.json';
 
-export const SERVER_URL = 'http://52.15.192.135:8080/';
+export const SERVER_URL = 'http://localhost:8080/';
 export const CLIENT_VERSION = pjson.version;
 export const REACT_VERSION = pjson.dependencies.react;

--- a/app/client/src/index.js
+++ b/app/client/src/index.js
@@ -1,17 +1,19 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter, Switch, Route } from 'react-router-dom'
+import { CookiesProvider } from 'react-cookie';
 import App from './App';
 
 import './css/cardinal.css';
 
 
 ReactDOM.render((
-  //<App />
-    <BrowserRouter>
-        <Switch>
-            <Route path="/" component={App}/>
-        </Switch>
-    </BrowserRouter>)
+    <CookiesProvider>
+        <BrowserRouter>
+            <Switch>
+                <Route path="/" component={App}/>
+            </Switch>
+        </BrowserRouter>
+    </CookiesProvider>)
 ,document.getElementById('root')
 );

--- a/app/client/src/pages/Contact.js
+++ b/app/client/src/pages/Contact.js
@@ -1,4 +1,6 @@
 import React, { Component } from 'react';
+import Cookies from 'universal-cookie';
+
 import ContactPage from '../components/contact/ContactPage';
 
 import { SERVER_URL} from '../config';
@@ -13,10 +15,9 @@ class Contact extends Component{
     }
 
     componentDidMount() {
-        const search = this.props.location.search; // could be '?foo=bar'
-        const params = new URLSearchParams(search);
-        const lang = params.get('lang'); // bar
-        var query = lang != null ? "?lang=" + lang : "";
+        const cookies = new Cookies();
+        var query = "?lang=" + cookies.get('lang');
+
         fetch(SERVER_URL + 'home/platform' + query)
             .then(r => r.json())
             .then(json => this.setState({serverInfo: json}))

--- a/app/client/src/pages/Ecosystem.js
+++ b/app/client/src/pages/Ecosystem.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import Cookies from 'universal-cookie';
 
 import MainEcosystem from '../components/ecosystem/MainEcosystem';
 import HowItWorks from '../components/ecosystem/HowItWorks';
@@ -22,10 +23,9 @@ class Ecosystem extends Component{
     }
 
     componentDidMount() {
-        const search = this.props.location.search; // could be '?foo=bar'
-        const params = new URLSearchParams(search);
-        const lang = params.get('lang'); // bar
-        var query = lang != null ? "?lang=" + lang : "";
+        const cookies = new Cookies();
+        var query = "?lang=" + cookies.get('lang');
+
         fetch(SERVER_URL + 'home/ecosystem' + query)
           .then(r => r.json())
           .then(json => this.setState({serverInfo: json}))

--- a/app/client/src/pages/Home.js
+++ b/app/client/src/pages/Home.js
@@ -1,8 +1,9 @@
 import React, { Component } from 'react';
+import Cookies from 'universal-cookie';
+
 import ProductsCarousel from '../components/home/ProductsCarousel';
 import CardinalInfo from '../components/home/CardinalInfo';
 import MainBanner from '../components/home/MainBanner';
-
 import InfoGrid from '../components/home/InfoGrid';
 import TrustedCompanies from '../components/home/TrustedCompanies';
 import { SERVER_URL, CLIENT_VERSION, REACT_VERSION } from '../config';
@@ -22,10 +23,9 @@ class Home extends Component{
     }
 
     componentDidMount() {
-        const search = this.props.location.search; // could be '?foo=bar'
-        const params = new URLSearchParams(search);
-        const lang = params.get('lang'); // bar
-        var query = lang != null ? "?lang=" + lang : "";
+        const cookies = new Cookies();
+        var query = "?lang=" + cookies.get('lang');
+
         fetch(SERVER_URL + 'application' + query)
           .then(r => r.json())
           .then(json => this.setState({serverInfo: json}))

--- a/app/client/src/pages/Kit.js
+++ b/app/client/src/pages/Kit.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import Cookies from 'universal-cookie';
 
 import MainKit from '../components/kit/MainKit';
 import InfoGrid from '../components/kit/InfoGrid';
@@ -21,10 +22,9 @@ class Kit extends Component{
     }
 
     componentDidMount() {
-        const search = this.props.location.search; // could be '?foo=bar'
-        const params = new URLSearchParams(search);
-        const lang = params.get('lang'); // bar
-        var query = lang != null ? "?lang=" + lang : "";
+        const cookies = new Cookies();
+        var query = "?lang=" + cookies.get('lang');
+
         fetch(SERVER_URL + 'home/kit' + query)
           .then(r => r.json())
           .then(json => this.setState({serverInfo: json}))

--- a/app/client/src/pages/Platform.js
+++ b/app/client/src/pages/Platform.js
@@ -1,4 +1,6 @@
 import React, { Component } from 'react';
+import Cookies from 'universal-cookie';
+
 import MainPlatform from '../components/platform/MainPlatform';
 import CourseOverview from '../components/platform/CourseOverview';
 import PlatformFeatures from '../components/platform/PlatformFeatures';
@@ -14,10 +16,9 @@ class Platform extends Component{
     }
 
     componentDidMount() {
-        const search = this.props.location.search; // could be '?foo=bar'
-        const params = new URLSearchParams(search);
-        const lang = params.get('lang'); // bar
-        var query = lang != null ? "?lang=" + lang : "";
+        const cookies = new Cookies();
+        var query = "?lang=" + cookies.get('lang');
+
         fetch(SERVER_URL + 'home/platform' + query)
             .then(r => r.json())
             .then(json => this.setState({serverInfo: json}))

--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -1301,7 +1301,7 @@ cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
 
-cookie@0.3.1:
+cookie@0.3.1, cookie@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
 
@@ -4110,7 +4110,7 @@ promise@7.1.1, promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@~15.5.7:
+prop-types@^15.0.0, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@~15.5.7:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
@@ -4209,6 +4209,15 @@ react-bootstrap@^0.30.8:
     react-prop-types "^0.4.0"
     uncontrollable "^4.0.1"
     warning "^3.0.0"
+
+react-cookie@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/react-cookie/-/react-cookie-2.0.8.tgz#2b551c8d80f8c1973ac9347aab61b152c6313398"
+  dependencies:
+    hoist-non-react-statics "^1.2.0"
+    prop-types "^15.0.0"
+    react "^15.0.0"
+    universal-cookie "^2.0.1"
 
 react-dev-utils@^0.5.2:
   version "0.5.2"
@@ -4327,7 +4336,7 @@ react-scripts@0.9.5:
   optionalDependencies:
     fsevents "1.0.17"
 
-react@^15.4.2:
+react@^15.0.0, react@^15.4.2:
   version "15.5.4"
   resolved "https://registry.yarnpkg.com/react/-/react-15.5.4.tgz#fa83eb01506ab237cdc1c8c3b1cea8de012bf047"
   dependencies:
@@ -5103,6 +5112,13 @@ uniqid@^4.0.0:
 uniqs@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/uniqs/-/uniqs-2.0.0.tgz#ffede4b36b25290696e6e165d4a59edb998e6b02"
+
+universal-cookie@^2.0.1:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/universal-cookie/-/universal-cookie-2.0.8.tgz#e9ab9a2a665bcd847917caee5b1a4c17598eabb9"
+  dependencies:
+    cookie "^0.3.1"
+    object-assign "^4.1.0"
 
 unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
**What this PR do?**
This PR adds the language of the pages into a cookie so the languages are kept throughout the whole navigation.

**How can this be tested?**
Follow the README.md steps and in the webpage use the query param `lang` to change the languages, currently, we only support `en` and `es`.